### PR TITLE
Add GitHub Pages build workflow

### DIFF
--- a/gx-token-site/.eslintrc.cjs
+++ b/gx-token-site/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['react', '@typescript-eslint'],
+  settings: {
+    react: { version: 'detect' },
+  },
+  rules: {},
+}

--- a/gx-token-site/.gitignore
+++ b/gx-token-site/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.dist
+.vite

--- a/gx-token-site/.prettierrc
+++ b/gx-token-site/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": false
+}

--- a/gx-token-site/README.md
+++ b/gx-token-site/README.md
@@ -1,0 +1,55 @@
+# GX Token Site
+
+A Vite + React + TypeScript project styled with Tailwind CSS. The site targets desktop browsers and uses a dark sci-fi palette.
+
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+## Development
+
+Start the dev server with hot reload:
+
+```bash
+npm run dev
+```
+
+## Production Build
+
+Create a production bundle and copy it to `docs/` for GitHub Pages:
+
+```bash
+npm run build:prod
+```
+
+## Deploy to GitHub Pages
+
+Example GitHub Actions workflow:
+
+```yaml
+name: Deploy
+on:
+  push:
+    branches: [main]
+
+jobs:
+  gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build:prod
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_dir: docs
+```
+
+The generated site will be served from the `docs/` directory on the `gh-pages` branch.

--- a/gx-token-site/index.html
+++ b/gx-token-site/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GX Token</title>
+  </head>
+  <body class="min-w-[1280px] bg-background text-accent">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/gx-token-site/package.json
+++ b/gx-token-site/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "gx-token-site",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "build:prod": "vite build && rm -rf docs && cp -r dist docs",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "prettier": "^3.0.3",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.34",
+    "autoprefixer": "^10.4.17",
+    "typescript": "^5.2.2",
+    "vite": "^5.2.0"
+  }
+}

--- a/gx-token-site/postcss.config.cjs
+++ b/gx-token-site/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/gx-token-site/src/App.tsx
+++ b/gx-token-site/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+function App() {
+  return (
+    <div className="min-h-screen bg-background text-accent flex items-center justify-center">
+      <h1 className="text-4xl">GX Token</h1>
+    </div>
+  )
+}
+
+export default App

--- a/gx-token-site/src/index.css
+++ b/gx-token-site/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply min-w-[1280px];
+}

--- a/gx-token-site/src/main.tsx
+++ b/gx-token-site/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/gx-token-site/tailwind.config.cjs
+++ b/gx-token-site/tailwind.config.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0d0d0d',
+        accent: '#14e956',
+      },
+    },
+    screens: {
+      desktop: '1280px',
+    },
+  },
+  plugins: [],
+}

--- a/gx-token-site/tsconfig.json
+++ b/gx-token-site/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/gx-token-site/tsconfig.node.json
+++ b/gx-token-site/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/gx-token-site/vite.config.ts
+++ b/gx-token-site/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- set up README with setup, dev and deploy instructions
- add build:prod script to package.json for GitHub Pages

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run build:prod` *(fails: vite not found)*